### PR TITLE
Led turned on by accident

### DIFF
--- a/stm32h750b_discovery_lcd.c
+++ b/stm32h750b_discovery_lcd.c
@@ -1360,7 +1360,7 @@ static void LTDC_MspInit(LTDC_HandleTypeDef *hltdc)
     HAL_GPIO_Init(GPIOI, &gpio_init_structure);
 
     /* GPIOJ configuration */
-    gpio_init_structure.Pin       = GPIO_PIN_All;
+    gpio_init_structure.Pin       = GPIO_PIN_All & (~GPIO_PIN_2);
     gpio_init_structure.Alternate = GPIO_AF14_LTDC;
     HAL_GPIO_Init(GPIOJ, &gpio_init_structure);
     /* GPIOK configuration */


### PR DESCRIPTION
## IMPORTANT INFORMATION

To the best of my ability I cannot see why this wasn't fixed before, tho the schematics provided might be wrong.
Since this is a BSP for a specific board and I have that board, the changes mentioned seem to work.

Please carefully verify this change, but if PJ2 is connected just to the green user led, it should not be modified in this section of BSP.

Source:
<img width="300" height="338" alt="image" src="https://github.com/user-attachments/assets/66a8e80f-8d61-4527-9d49-918d7a9bce80" />


### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
