### PR TITLE
Led turned on by accident

### DIFF
--- a/stm32h750b_discovery_lcd.c
+++ b/stm32h750b_discovery_lcd.c
@@ -1360,7 +1360,7 @@ static void LTDC_MspInit(LTDC_HandleTypeDef *hltdc)
     HAL_GPIO_Init(GPIOI, &gpio_init_structure);
 
     /* GPIOJ configuration */
-    gpio_init_structure.Pin       = GPIO_PIN_All;
+    gpio_init_structure.Pin       = GPIO_PIN_All & (~GPIO_PIN_2);
     gpio_init_structure.Alternate = GPIO_AF14_LTDC;
     HAL_GPIO_Init(GPIOJ, &gpio_init_structure);
     /* GPIOK configuration */


### PR DESCRIPTION
## IMPORTANT INFORMATION

To the best of my ability, the pin PJ2 is mentioned here accidentally.
It should only be connected to the USRER LED (LD7).

Source:
<img width="300" height="338" alt="image" src="https://github.com/user-attachments/assets/3c706d28-f3db-420c-a55f-99be0023c7c4" />


### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
